### PR TITLE
feat: tiled attention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 .mypy_cache
+a_unet.egg-info/

--- a/README.md
+++ b/README.md
@@ -157,3 +157,14 @@ time = [0.2, 0.5]
 embedding = torch.randn(2, 512, 768)
 y = unet(x, time=time, embedding=embedding) # [2, 2, 64, 64]
 ```
+
+
+### Flash Attention
+
+To enable flash attention, first install the latest xformers as described [here](https://github.com/facebookresearch/xformers#installing-xformers). After, set the `use_flash_attention` variable in `config`:
+
+```python
+from a_unet import config
+
+config.use_flash_attention = True
+```

--- a/a_unet/apex.py
+++ b/a_unet/apex.py
@@ -18,6 +18,7 @@ from .blocks import (
     Modulation,
     Module,
     Packed,
+    Tiled,
     ResnetBlock,
     Select,
     Sequential,
@@ -204,6 +205,47 @@ def LinearCrossAttentionItem(
         )
     )
 
+def TiledAttentionItem(
+    channels: Optional[int] = None,
+    attention_features: Optional[int] = None,
+    attention_heads: Optional[int] = None,
+    tile_size: Optional[int] = None,
+    **kwargs,
+) -> nn.Module:
+    msg = "TiledAttentionItem requires tile_size"
+    assert (
+        exists(tile_size)
+    ), msg
+    return Tiled(
+        tile_size,
+        AttentionItem(  # type: ignore
+            channels=channels,
+            attention_features=attention_features,
+            attention_heads=attention_heads,
+        )
+    )
+
+def TiledCrossAttentionItem(
+    channels: Optional[int] = None,
+    attention_features: Optional[int] = None,
+    attention_heads: Optional[int] = None,
+    embedding_features: Optional[int] = None,
+    tile_size: Optional[int] = None,
+    **kwargs,
+) -> nn.Module:
+    msg = "TiledCrossAttentionItem requires tile_size"
+    assert (
+        exists(tile_size)
+    ), msg
+    return Tiled(
+        tile_size,
+        CrossAttentionItem(  # type: ignore
+            channels=channels,
+            attention_features=attention_features,
+            attention_heads=attention_heads,
+            embedding_features=embedding_features,
+        )
+    )
 
 def FeedForwardItem(
     channels: Optional[int] = None, attention_multiplier: Optional[int] = None, **kwargs

--- a/a_unet/apex.py
+++ b/a_unet/apex.py
@@ -205,6 +205,7 @@ def LinearCrossAttentionItem(
         )
     )
 
+
 def TiledAttentionItem(
     channels: Optional[int] = None,
     attention_features: Optional[int] = None,
@@ -213,17 +214,16 @@ def TiledAttentionItem(
     **kwargs,
 ) -> nn.Module:
     msg = "TiledAttentionItem requires tile_size"
-    assert (
-        exists(tile_size)
-    ), msg
+    assert exists(tile_size), msg
     return Tiled(
         tile_size,
         AttentionItem(  # type: ignore
             channels=channels,
             attention_features=attention_features,
             attention_heads=attention_heads,
-        )
+        ),
     )
+
 
 def TiledCrossAttentionItem(
     channels: Optional[int] = None,
@@ -234,9 +234,7 @@ def TiledCrossAttentionItem(
     **kwargs,
 ) -> nn.Module:
     msg = "TiledCrossAttentionItem requires tile_size"
-    assert (
-        exists(tile_size)
-    ), msg
+    assert exists(tile_size), msg
     return Tiled(
         tile_size,
         CrossAttentionItem(  # type: ignore
@@ -244,8 +242,9 @@ def TiledCrossAttentionItem(
             attention_features=attention_features,
             attention_heads=attention_heads,
             embedding_features=embedding_features,
-        )
+        ),
     )
+
 
 def FeedForwardItem(
     channels: Optional[int] = None, attention_multiplier: Optional[int] = None, **kwargs

--- a/a_unet/blocks.py
+++ b/a_unet/blocks.py
@@ -6,6 +6,7 @@ import torch.nn.functional as F
 from einops import pack, rearrange, reduce, repeat, unpack
 from torch import Tensor, einsum, nn
 from typing_extensions import TypeGuard
+from . import config
 
 V = TypeVar("V")
 
@@ -231,20 +232,27 @@ def AttentionBase(features: int, head_features: int, num_heads: int) -> nn.Modul
     scale = head_features**-0.5
     mid_features = head_features * num_heads
     to_out = nn.Linear(in_features=mid_features, out_features=features, bias=False)
+    if config.use_flash_attention:
+        import xformers
+        import xformers.ops
 
     def forward(
         q: Tensor, k: Tensor, v: Tensor, mask: Optional[Tensor] = None
     ) -> Tensor:
-        h = num_heads
-        # Split heads
-        q, k, v = map(lambda t: rearrange(t, "b n (h d) -> b h n d", h=h), (q, k, v))
-        # Compute similarity matrix and add eventual mask
-        sim = einsum("... n d, ... m d -> ... n m", q, k) * scale
-        # Get attention matrix with softmax
-        attn = sim.softmax(dim=-1)
-        # Compute values
-        out = einsum("... n m, ... m d -> ... n d", attn, v)
-        out = rearrange(out, "b h n d -> b n (h d)")
+        if config.use_flash_attention:
+            # Use memory efficient attention
+            out = xformers.ops.memory_efficient_attention(q, k, v)
+        else:
+            h = num_heads
+            # Split heads
+            q, k, v = map(lambda t: rearrange(t, "b n (h d) -> b h n d", h=h), (q, k, v))
+            # Compute similarity matrix and add eventual mask
+            sim = einsum("... n d, ... m d -> ... n m", q, k) * scale
+            # Get attention matrix with softmax
+            attn = sim.softmax(dim=-1)
+            # Compute values
+            out = einsum("... n m, ... m d -> ... n d", attn, v)
+            out = rearrange(out, "b h n d -> b n (h d)")
         return to_out(out)
 
     return Module([to_out], forward)

--- a/a_unet/blocks.py
+++ b/a_unet/blocks.py
@@ -7,7 +7,6 @@ from einops import pack, rearrange, reduce, repeat, unpack
 from torch import Tensor, einsum, nn
 from typing_extensions import TypeGuard
 from . import config
-from functools import partial
 
 V = TypeVar("V")
 
@@ -126,12 +125,10 @@ class Tiled(Sequential):
     ) -> Tensor:
         t = int(x.shape[2] / self.tile_size)
         x = rearrange(x, "b c (t k) -> (b t) c k", k=self.tile_size)
-        x = super().forward(
-            x,
-            f,
-            context.repeat_interleave(t, dim=0) if not context is None else None,
-            *args,
-        )
+        if not context is None:
+            x = super().forward(x, f, context.repeat_interleave(t, dim=0), *args)
+        else:
+            x = super().forward(x, *args)
         x = rearrange(x, "(b t) c k -> b c (t k)", t=t)
         return x
 

--- a/a_unet/config.py
+++ b/a_unet/config.py
@@ -1,0 +1,3 @@
+# Runtime configuration
+
+use_flash_attention = False  # Whether we should use xformers' Flash Attention impl.


### PR DESCRIPTION
Tiled Attention is a more efficient way to deal with large attention windows when global context doesn't really matter. The idea is to take a batch size of ([4 songs, 256 channels, 1024 samples]) and turn it into ([8 "songs", 256 channels, 512 samples]) which is more manageable for attention, then recombine them after. 

This PR adds `TiledAttentionItem` and `TiledCrossAttentionItem`

Built on Flash Attention PR.