### PR TITLE
Adding dilation and dropout

### DIFF
--- a/a_unet/apex.py
+++ b/a_unet/apex.py
@@ -368,10 +368,10 @@ class Block(nn.Module):
         # Build items stack: items down -> inner block -> items up
         items_all: List[nn.Module] = []
         exp = list(reversed(range(99999)))
-        items_all += [item_t(**items_kwargs, dilation=resnet_dilation_factor**exp.pop()) if item_t.__name__ == 'ResnetItem' else item_t(**items_kwargs) for item_t in items_down]
+        items_all += [item_t(dilation=resnet_dilation_factor**exp.pop(), **items_kwargs) if item_t.__name__ == 'ResnetItem' else item_t(**items_kwargs) for item_t in items_down]
         items_all += [inner_block] if exists(inner_block) else []
         exp = list(reversed(range(99999)))
-        items_all += [item_t(**items_kwargs, dilation=resnet_dilation_factor**exp.pop()) if item_t.__name__ == 'ResnetItem' else item_t(**items_kwargs) for item_t in items_up]
+        items_all += [item_t(dilation=resnet_dilation_factor**exp.pop(), **items_kwargs) if item_t.__name__ == 'ResnetItem' else item_t(**items_kwargs) for item_t in items_up]
 
         self.skip_adapter = skip_adapter_t(**items_kwargs)
         self.block = Sequential(*items_all)

--- a/a_unet/apex.py
+++ b/a_unet/apex.py
@@ -363,7 +363,7 @@ class Block(nn.Module):
         for idx, item in enumerate(items):
             print(idx, item.__name__)
             if item.__name__ == 'ResnetItem':
-                items[idx] = T(item)(dilation=resnet_dilation_factor**cycle)
+                items[idx] = T(item)(dilation=resnet_dilation_factor**cycle, **kwargs)
                 print(items[idx]())
                 cycle+=1
 

--- a/a_unet/apex.py
+++ b/a_unet/apex.py
@@ -360,8 +360,10 @@ class Block(nn.Module):
 
         cycle = 0
         print(items)
+        print(type(ResnetItem))
         for idx, item in enumerate(items):
             print(idx, item)
+            print(type(item))
             if isinstance(item, ResnetItem):
                 items[idx] = T(item)(dilation=dilation_factor**cycle)
                 cycle+=1

--- a/a_unet/apex.py
+++ b/a_unet/apex.py
@@ -120,8 +120,7 @@ def ResnetItem(
         out_channels=channels,
         kernel_size=resnet_kernel_size,
         conv_block_t=conv_block_t,
-        dilation_factor = resnet_dilation_factor,
-        dropout_rate = resnet_dropout_rate
+        dropout_rate = resnet_dropout_rate,
     )
 
 

--- a/a_unet/apex.py
+++ b/a_unet/apex.py
@@ -357,8 +357,6 @@ class Block(nn.Module):
         super().__init__()
         out_channels = default(out_channels, in_channels)
 
-        exp = list(reversed(range(99999)))
-
         items_up = default(items_up, items)  # type: ignore
         items_down = [downsample_t] + list(items)
         items_up = list(items_up) + [upsample_t]
@@ -368,8 +366,10 @@ class Block(nn.Module):
 
         # Build items stack: items down -> inner block -> items up
         items_all: List[nn.Module] = []
+        exp = list(reversed(range(99999)))
         items_all += [item_t(**items_kwargs, dilation=resnet_dilation_factor**exp.pop()) if item_t.__name__ == 'ResnetItem' else item_t(**items_kwargs) for item_t in items_down]
         items_all += [inner_block] if exists(inner_block) else []
+        exp = list(reversed(range(99999)))
         items_all += [item_t(**items_kwargs, dilation=resnet_dilation_factor**exp.pop()) if item_t.__name__ == 'ResnetItem' else item_t(**items_kwargs) for item_t in items_up]
 
         self.skip_adapter = skip_adapter_t(**items_kwargs)

--- a/a_unet/apex.py
+++ b/a_unet/apex.py
@@ -353,6 +353,7 @@ class Block(nn.Module):
         items_up: Optional[Sequence[Callable]] = None,
         out_channels: Optional[int] = None,
         inner_block: Optional[nn.Module] = None,
+        resnet_dilation_factor: Optional[int] = None,
         **kwargs,
     ):
         super().__init__()

--- a/a_unet/apex.py
+++ b/a_unet/apex.py
@@ -106,13 +106,12 @@ def ResnetItem(
     dim: Optional[int] = None,
     channels: Optional[int] = None,
     resnet_groups: Optional[int] = None,
-    resnet_dilation_factor: Optional[int] = None,
     resnet_dropout_rate: Optional[float] = None,
     resnet_kernel_size: int = 3,
     **kwargs,
 ) -> nn.Module:
-    msg = "ResnetItem requires dim, channels, resnet_groups, resnet_dropout_rate, and resnet_dilation_factor"
-    assert exists(dim) and exists(channels) and exists(resnet_groups) and exists(resnet_dilation_factor) and exists(resnet_dropout_rate), msg
+    msg = "ResnetItem requires dim, channels, resnet_groups, and resnet_dropout_rate"
+    assert exists(dim) and exists(channels) and exists(resnet_groups) and exists(resnet_dropout_rate), msg
     Item = SelectX(ResnetBlock)
     conv_block_t = T(ConvBlock)(norm_t=T(nn.GroupNorm)(num_groups=resnet_groups), drop_t=T(nn.Dropout)(p=resnet_dropout_rate))
     return Item(  # type: ignore

--- a/a_unet/apex.py
+++ b/a_unet/apex.py
@@ -357,14 +357,7 @@ class Block(nn.Module):
         super().__init__()
         out_channels = default(out_channels, in_channels)
 
-        cycle = 0
-        print(items)
-        for idx, item in enumerate(items):
-            print(idx, item.__name__)
-            if item.__name__ == 'ResnetItem':
-                items[idx] = T(item)(dilation=resnet_dilation_factor**cycle, **kwargs)
-                print(items[idx], resnet_dilation_factor**cycle)
-                cycle+=1
+        exp = list(reversed(range(99999)))
 
         items_up = default(items_up, items)  # type: ignore
         items_down = [downsample_t] + list(items)
@@ -375,9 +368,9 @@ class Block(nn.Module):
 
         # Build items stack: items down -> inner block -> items up
         items_all: List[nn.Module] = []
-        items_all += [item_t(**items_kwargs) for item_t in items_down]
+        items_all += [item_t(**items_kwargs, dilation=resnet_dilation_factor**exp.pop()) if item_t.__name__ == 'ResnetItem' else item_t(**items_kwargs) for item_t in items_down]
         items_all += [inner_block] if exists(inner_block) else []
-        items_all += [item_t(**items_kwargs) for item_t in items_up]
+        items_all += [item_t(**items_kwargs, dilation=resnet_dilation_factor**exp.pop()) if item_t.__name__ == 'ResnetItem' else item_t(**items_kwargs) for item_t in items_up]
 
         self.skip_adapter = skip_adapter_t(**items_kwargs)
         self.block = Sequential(*items_all)

--- a/a_unet/apex.py
+++ b/a_unet/apex.py
@@ -122,7 +122,6 @@ def ResnetItem(
         dilation=dilation,
         kernel_size=resnet_kernel_size,
         conv_block_t=conv_block_t,
-        dropout_rate=resnet_dropout_rate,
     )
 
 

--- a/a_unet/apex.py
+++ b/a_unet/apex.py
@@ -363,7 +363,7 @@ class Block(nn.Module):
             print(idx, item.__name__)
             if item.__name__ == 'ResnetItem':
                 items[idx] = T(item)(dilation=resnet_dilation_factor**cycle, **kwargs)
-                print(items[idx]())
+                print(items[idx], resnet_dilation_factor**cycle)
                 cycle+=1
 
         items_up = default(items_up, items)  # type: ignore

--- a/a_unet/apex.py
+++ b/a_unet/apex.py
@@ -105,13 +105,14 @@ def UpsampleItem(
 def ResnetItem(
     dim: Optional[int] = None,
     channels: Optional[int] = None,
+    dilation: Optional[int] = None
     resnet_groups: Optional[int] = None,
     resnet_dropout_rate: Optional[float] = None,
     resnet_kernel_size: int = 3,
     **kwargs,
 ) -> nn.Module:
-    msg = f"ResnetItem requires dim ({dim}), channels ({channels}), resnet_groups ({resnet_groups}), and resnet_dropout_rate ({resnet_dropout_rate})"
-    assert exists(dim) and exists(channels) and exists(resnet_groups) and exists(resnet_dropout_rate), msg
+    msg = f"ResnetItem requires dim ({dim}), channels ({channels}), resnet_groups ({resnet_groups}), resnet_dropout_rate ({resnet_dropout_rate}), and dilation ({dilation})"
+    assert exists(dim) and exists(channels) and exists(resnet_groups) and exists(resnet_dropout_rate) and exists(dilation), msg
     Item = SelectX(ResnetBlock)
     conv_block_t = T(ConvBlock)(norm_t=T(nn.GroupNorm)(num_groups=resnet_groups), drop_t=T(nn.Dropout)(p=resnet_dropout_rate))
     return Item(  # type: ignore

--- a/a_unet/apex.py
+++ b/a_unet/apex.py
@@ -105,7 +105,7 @@ def UpsampleItem(
 def ResnetItem(
     dim: Optional[int] = None,
     channels: Optional[int] = None,
-    dilation: Optional[int] = None
+    dilation: Optional[int] = None,
     resnet_groups: Optional[int] = None,
     resnet_dropout_rate: Optional[float] = None,
     resnet_kernel_size: int = 3,

--- a/a_unet/apex.py
+++ b/a_unet/apex.py
@@ -360,11 +360,9 @@ class Block(nn.Module):
 
         cycle = 0
         print(items)
-        print(type(ResnetItem))
         for idx, item in enumerate(items):
-            print(idx, item)
-            print(type(item))
-            if isinstance(item, ResnetItem):
+            print(idx, item.__name__)
+            if item.__name__ == 'ResnetItem':
                 items[idx] = T(item)(dilation=dilation_factor**cycle)
                 cycle+=1
 

--- a/a_unet/apex.py
+++ b/a_unet/apex.py
@@ -359,7 +359,9 @@ class Block(nn.Module):
         out_channels = default(out_channels, in_channels)
 
         cycle = 0
+        print(items)
         for idx, item in enumerate(items):
+            print(idx, item)
             if isinstance(item, ResnetItem):
                 items[idx] = T(item)(dilation=dilation_factor**cycle)
                 cycle+=1

--- a/a_unet/apex.py
+++ b/a_unet/apex.py
@@ -118,9 +118,10 @@ def ResnetItem(
         dim=dim,
         in_channels=channels,
         out_channels=channels,
+        dilation=dilation,
         kernel_size=resnet_kernel_size,
         conv_block_t=conv_block_t,
-        dropout_rate = resnet_dropout_rate,
+        dropout_rate=resnet_dropout_rate,
     )
 
 

--- a/a_unet/apex.py
+++ b/a_unet/apex.py
@@ -110,7 +110,7 @@ def ResnetItem(
     resnet_kernel_size: int = 3,
     **kwargs,
 ) -> nn.Module:
-    msg = "ResnetItem requires dim, channels, resnet_groups, and resnet_dropout_rate"
+    msg = f"ResnetItem requires dim ({dim}), channels ({channels}), resnet_groups ({resnet_groups}), and resnet_dropout_rate ({resnet_dropout_rate})"
     assert exists(dim) and exists(channels) and exists(resnet_groups) and exists(resnet_dropout_rate), msg
     Item = SelectX(ResnetBlock)
     conv_block_t = T(ConvBlock)(norm_t=T(nn.GroupNorm)(num_groups=resnet_groups), drop_t=T(nn.Dropout)(p=resnet_dropout_rate))

--- a/a_unet/apex.py
+++ b/a_unet/apex.py
@@ -363,7 +363,8 @@ class Block(nn.Module):
         for idx, item in enumerate(items):
             print(idx, item.__name__)
             if item.__name__ == 'ResnetItem':
-                items[idx] = T(item)(dilation=dilation_factor**cycle)
+                items[idx] = T(item)(dilation=resnet_dilation_factor**cycle)
+                print(items[idx]())
                 cycle+=1
 
         items_up = default(items_up, items)  # type: ignore


### PR DESCRIPTION
This PR adapts the residual units inside the UNet encoder and decoder blocks to follow more closely the encoder/decoder architecture described in both:

- [Soundstream](https://arxiv.org/abs/2107.03312)
and
- [EnCodec](https://arxiv.org/pdf/2210.13438)

Specifically it adapts the internal residual units to follow an exponentially increasing dilation schedule by way of a dilation factor base (usually 3):

- dilation=3^0 -> dilation=3^1 -> dilation=3^2

As well as adapting the second convolutional layer in the residual unit to use dilation=1 and kernel_size=1. This follows the residual units described in the papers above. 

<img width="283" alt="Screen Shot 2023-06-12 at 3 20 16 PM" src="https://github.com/archinetai/a-unet/assets/19558986/11547f25-60da-4713-8c48-23b4aad7022e">

To optionally remove dilation from the blocks, use dilation factor of 1:

- dilation=1^0 -> dilation=1^1 -> dilation=1^2 

Additionally I have added dropout in the residual units for experimentation after the activation. I tried to adhere as closely as possible to the code style you have laid out, let me know if there are stylistic or other tweaks you'd like to see. Hopefully this is a useful contribution! I have already been experimenting in adding dilation to https://github.com/archinetai/audio-diffusion-pytorch using this update and will push a PR in that repo as well for controlling dilation factor and dropout for UNet use in diffusion.

🙏  